### PR TITLE
Avoid duplicated snapshots topic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,6 +95,7 @@ lazy val sample_books_catalog = (project in file("examples/books-catalog"))
         .configs(IntegrationTest)
         .settings(
             name := "sample-books-catalog",
+            fork := true,
             Defaults.itSettings,
             publish / skip := true,
             libraryDependencies ++= testDependencies("it, test"),
@@ -105,6 +106,7 @@ lazy val sample_bank_account = (project in file("examples/bank-account"))
         .configs(IntegrationTest)
         .settings(
             name := "sample-bank-account",
+            fork := true,
             Defaults.itSettings,
             publish / skip := true,
             libraryDependencies ++= testDependencies("it, test"),

--- a/es4kafka-test/src/main/scala/es4kafka/testing/EventSourcingTopologyTest.scala
+++ b/es4kafka-test/src/main/scala/es4kafka/testing/EventSourcingTopologyTest.scala
@@ -34,14 +34,14 @@ class EventSourcingTopologyTest[K, VCommand <: Command[K], VEvent <: Event, VSna
   }
 
   val snapshotOutputTopic: OutputTopicTest[K, VSnapshot] =
-    new OutputTopicTest(driver, aggregateConfig.topicSnapshots)
+    new OutputTopicTest(driver, aggregateConfig.topicChangelog)
 
   def readSnapshots: Map[K, VSnapshot] = {
     snapshotOutputTopic.readValuesToMap()
   }
 
   val snapshotsStore: KeyValueStoreTest[K, VSnapshot] =
-    new KeyValueStoreTest(driver, aggregateConfig.storeSnapshots)
+    new KeyValueStoreTest(driver, aggregateConfig.storeChangelog)
 
   def readSnapshotsFromStore: Seq[(K, VSnapshot)] = {
     snapshotsStore.readValuesToSeq()

--- a/es4kafka/src/main/resources/reference.conf
+++ b/es4kafka/src/main/resources/reference.conf
@@ -1,6 +1,6 @@
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
-  loglevel = "DEBUG"
+  loglevel = "INFO"
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 }
 

--- a/es4kafka/src/main/scala/es4kafka/AggregateConfig.scala
+++ b/es4kafka/src/main/scala/es4kafka/AggregateConfig.scala
@@ -6,13 +6,13 @@ trait AggregateConfig {
   val aggregateName: String
   val namingConvention: KafkaNamingConvention
 
-  lazy val storeSnapshots: String = namingConvention.kafkaStreamsStore(s"$aggregateName.snapshots")
-  lazy val storeEventsByMsgId: String = namingConvention.kafkaStreamsStore(s"$aggregateName.eventsByMsgId")
+  lazy val storeSnapshots: String = namingConvention.store(aggregateName)
+  lazy val storeEventsByMsgId: String = namingConvention.store(s"$aggregateName.eventsByMsgId")
 
-  lazy val topicCommands: String = namingConvention.kafkaCommandsTopic(aggregateName)
-  lazy val topicEvents: String = namingConvention.kafkaEventsTopic(aggregateName)
+  lazy val topicCommands: String = namingConvention.topicCommands(aggregateName)
+  lazy val topicEvents: String = namingConvention.topicEvents(aggregateName)
   // Snapshots are handled internally by the changelog topic created to store snapshot state
-  lazy val topicSnapshots: String = namingConvention.kafkaStreamsChangelogTopic(storeSnapshots)
+  lazy val topicSnapshots: String = namingConvention.topicStoreChangelog(storeSnapshots)
 
   // HTTP RPC segments
   lazy val httpPrefix: String = aggregateName

--- a/es4kafka/src/main/scala/es4kafka/AggregateConfig.scala
+++ b/es4kafka/src/main/scala/es4kafka/AggregateConfig.scala
@@ -6,16 +6,13 @@ trait AggregateConfig {
   val aggregateName: String
   val namingConvention: KafkaNamingConvention
 
-  lazy val topicCommands: String = namingConvention.kafkaCommandsTopic(aggregateName)
-  lazy val topicEvents: String = namingConvention.kafkaEventsTopic(aggregateName)
-  lazy val topicSnapshots: String = namingConvention.kafkaSnapshotsTopic(aggregateName)
-
   lazy val storeSnapshots: String = namingConvention.kafkaStreamsStore(s"$aggregateName.snapshots")
   lazy val storeEventsByMsgId: String = namingConvention.kafkaStreamsStore(s"$aggregateName.eventsByMsgId")
 
-  // Internal event sourcing elements
-  lazy val storeState: String = namingConvention.kafkaStreamsStore(s"$aggregateName.state")
-  lazy val topicStateChangelog: String = namingConvention.kafkaStreamsChangelogTopic(storeState)
+  lazy val topicCommands: String = namingConvention.kafkaCommandsTopic(aggregateName)
+  lazy val topicEvents: String = namingConvention.kafkaEventsTopic(aggregateName)
+  // Snapshots are handled internally by the changelog topic created to store snapshot state
+  lazy val topicSnapshots: String = namingConvention.kafkaStreamsChangelogTopic(storeSnapshots)
 
   // HTTP RPC segments
   lazy val httpPrefix: String = aggregateName

--- a/es4kafka/src/main/scala/es4kafka/AggregateConfig.scala
+++ b/es4kafka/src/main/scala/es4kafka/AggregateConfig.scala
@@ -6,13 +6,13 @@ trait AggregateConfig {
   val aggregateName: String
   val namingConvention: KafkaNamingConvention
 
-  lazy val storeSnapshots: String = namingConvention.store(aggregateName)
+  lazy val storeChangelog: String = namingConvention.store(aggregateName)
   lazy val storeEventsByMsgId: String = namingConvention.store(s"$aggregateName.eventsByMsgId")
 
   lazy val topicCommands: String = namingConvention.topicCommands(aggregateName)
   lazy val topicEvents: String = namingConvention.topicEvents(aggregateName)
-  // Snapshots are handled internally by the changelog topic created to store snapshot state
-  lazy val topicSnapshots: String = namingConvention.topicStoreChangelog(storeSnapshots)
+  // Snapshots are handled internally by the changelog topic created to store state changes
+  lazy val topicChangelog: String = namingConvention.topicStoreChangelog(storeChangelog)
 
   // HTTP RPC segments
   lazy val httpPrefix: String = aggregateName

--- a/es4kafka/src/main/scala/es4kafka/ProjectionConfig.scala
+++ b/es4kafka/src/main/scala/es4kafka/ProjectionConfig.scala
@@ -7,9 +7,9 @@ trait ProjectionConfig {
   val namingConvention: KafkaNamingConvention
 
   // Snapshots are handled internally by the changelog topic created to store snapshot state
-  lazy val topicSnapshots: String = namingConvention.topicStoreChangelog(storeSnapshots)
+  lazy val topicChangelog: String = namingConvention.topicStoreChangelog(storeChangelog)
 
-  lazy val storeSnapshots: String = namingConvention.store(projectionName)
+  lazy val storeChangelog: String = namingConvention.store(projectionName)
 
   // HTTP RPC segments
   lazy val httpPrefix: String = projectionName

--- a/es4kafka/src/main/scala/es4kafka/ProjectionConfig.scala
+++ b/es4kafka/src/main/scala/es4kafka/ProjectionConfig.scala
@@ -6,9 +6,10 @@ trait ProjectionConfig {
   val projectionName: String
   val namingConvention: KafkaNamingConvention
 
-  lazy val topicSnapshots: String = namingConvention.kafkaSnapshotsTopic(projectionName)
+  // Snapshots are handled internally by the changelog topic created to store snapshot state
+  lazy val topicSnapshots: String = namingConvention.topicStoreChangelog(storeSnapshots)
 
-  lazy val storeSnapshots: String = namingConvention.kafkaStreamsStore(s"$projectionName.snapshots")
+  lazy val storeSnapshots: String = namingConvention.store(projectionName)
 
   // HTTP RPC segments
   lazy val httpPrefix: String = projectionName

--- a/es4kafka/src/main/scala/es4kafka/administration/KafkaTopicAdmin.scala
+++ b/es4kafka/src/main/scala/es4kafka/administration/KafkaTopicAdmin.scala
@@ -57,9 +57,6 @@ class KafkaTopicAdmin(
   def addAggregate(aggregateConfig: AggregateConfig): KafkaTopicAdmin = {
     addPersistentTopic(aggregateConfig.topicCommands)
     addPersistentTopic(aggregateConfig.topicEvents)
-    // changelog topic is created automatically by Kafka Streams,
-    // but to be explicit we create it, also because we can need it as an input streams
-    // so we force it creating at startup
     addPersistentTopic(aggregateConfig.topicSnapshots, compact = true)
   }
 

--- a/es4kafka/src/main/scala/es4kafka/administration/KafkaTopicAdmin.scala
+++ b/es4kafka/src/main/scala/es4kafka/administration/KafkaTopicAdmin.scala
@@ -57,10 +57,10 @@ class KafkaTopicAdmin(
   def addAggregate(aggregateConfig: AggregateConfig): KafkaTopicAdmin = {
     addPersistentTopic(aggregateConfig.topicCommands)
     addPersistentTopic(aggregateConfig.topicEvents)
-    addPersistentTopic(aggregateConfig.topicSnapshots, compact = true)
-    // changelog topic is created automatically by Kafka Streams, but we need it as an input streams
+    // changelog topic is created automatically by Kafka Streams,
+    // but to be explicit we create it, also because we can need it as an input streams
     // so we force it creating at startup
-    addPersistentTopic(aggregateConfig.topicStateChangelog, compact = true)
+    addPersistentTopic(aggregateConfig.topicSnapshots, compact = true)
   }
 
   def addProjection(projectionConfig: ProjectionConfig): KafkaTopicAdmin = {

--- a/es4kafka/src/main/scala/es4kafka/administration/KafkaTopicAdmin.scala
+++ b/es4kafka/src/main/scala/es4kafka/administration/KafkaTopicAdmin.scala
@@ -57,11 +57,11 @@ class KafkaTopicAdmin(
   def addAggregate(aggregateConfig: AggregateConfig): KafkaTopicAdmin = {
     addPersistentTopic(aggregateConfig.topicCommands)
     addPersistentTopic(aggregateConfig.topicEvents)
-    addPersistentTopic(aggregateConfig.topicSnapshots, compact = true)
+    addPersistentTopic(aggregateConfig.topicChangelog, compact = true)
   }
 
   def addProjection(projectionConfig: ProjectionConfig): KafkaTopicAdmin = {
-    addPersistentTopic(projectionConfig.topicSnapshots, compact = true)
+    addPersistentTopic(projectionConfig.topicChangelog, compact = true)
   }
 
   def addPersistentTopic(name: String, compact: Boolean = false): KafkaTopicAdmin = {

--- a/es4kafka/src/main/scala/es4kafka/configs/ServiceConfig.scala
+++ b/es4kafka/src/main/scala/es4kafka/configs/ServiceConfig.scala
@@ -39,7 +39,7 @@ trait ServiceConfigHttp {
 trait ServiceConfigKafka extends ServiceConfig {
   lazy val kafkaBrokers: String = sys.env.getOrElse("KAFKA_BROKERS", "localhost:9092")
 
-  lazy val namingConvention: KafkaNamingConvention = new KafkaNamingConvention(applicationId, boundedContext)
+  lazy val namingConvention: KafkaNamingConvention = new KafkaNamingConvention(applicationId)
 }
 
 trait ServiceConfigKafkaStreams extends BaseConfig with ServiceConfigKafka with ServiceConfigHttp {

--- a/es4kafka/src/main/scala/es4kafka/datetime/InstantProvider.scala
+++ b/es4kafka/src/main/scala/es4kafka/datetime/InstantProvider.scala
@@ -3,7 +3,7 @@ package es4kafka.datetime
 import java.time.Instant
 
 object InstantProvider {
-  var current: InstantProvider = new DefaultInstantProvider
+  val default: InstantProvider = new DefaultInstantProvider
 }
 
 trait InstantProvider {

--- a/es4kafka/src/main/scala/es4kafka/kafka/KafkaNamingConvention.scala
+++ b/es4kafka/src/main/scala/es4kafka/kafka/KafkaNamingConvention.scala
@@ -1,21 +1,33 @@
 package es4kafka.kafka
 
+object KafkaNamingConvention {
+  val EVENTS: String = "events"
+  val COMMANDS: String = "commands"
+  val CHANGELOG: String = "changelog"
+  val SNAPSHOTS: String = "snapshots"
+
+  def topicRef(appId: String, name: String, kind: String): String = s"$appId-$name-$kind"
+  def topicRefSnapshots(appId: String, name: String): String = topicRef(appId, name, SNAPSHOTS)
+  def topicRefChangelog(appId: String, name: String): String = topicRef(appId, name, CHANGELOG)
+  def topicRefEvents(appId: String, name: String): String = topicRef(appId, name, EVENTS)
+}
+
 class KafkaNamingConvention(
     applicationId: String,
 ) {
   /**
    * Use the same convention of the changelog to have the same names on topics
    */
-  def topic(name: String, kind: String): String = s"$applicationId-$name-$kind"
+  def topic(name: String, kind: String): String = KafkaNamingConvention.topicRef(applicationId, name, kind)
 
-  def topicEvents(name: String): String = topic(name, "events")
-  def topicCommands(name: String): String = topic(name, "commands")
-  def topicSnapshots(name: String): String = topic(name, "snapshots")
+  def topicEvents(name: String): String = topic(name, KafkaNamingConvention.EVENTS)
+  def topicCommands(name: String): String = topic(name, KafkaNamingConvention.COMMANDS)
+  def topicSnapshots(name: String): String = topic(name, KafkaNamingConvention.SNAPSHOTS)
 
   /**
    * Changelog topic name is fixed and follows always the convention `{appId}-{storeName}-changelog``
    */
-  def topicStoreChangelog(storeName: String): String = topic(storeName, "changelog")
+  def topicStoreChangelog(storeName: String): String = topic(storeName, KafkaNamingConvention.CHANGELOG)
 
   def store(name: String): String = name
 

--- a/es4kafka/src/main/scala/es4kafka/kafka/KafkaNamingConvention.scala
+++ b/es4kafka/src/main/scala/es4kafka/kafka/KafkaNamingConvention.scala
@@ -4,10 +4,8 @@ object KafkaNamingConvention {
   val EVENTS: String = "events"
   val COMMANDS: String = "commands"
   val CHANGELOG: String = "changelog"
-  val SNAPSHOTS: String = "snapshots"
 
   def topicRef(appId: String, name: String, kind: String): String = s"$appId-$name-$kind"
-  def topicRefSnapshots(appId: String, name: String): String = topicRef(appId, name, SNAPSHOTS)
   def topicRefChangelog(appId: String, name: String): String = topicRef(appId, name, CHANGELOG)
   def topicRefEvents(appId: String, name: String): String = topicRef(appId, name, EVENTS)
 }
@@ -22,10 +20,9 @@ class KafkaNamingConvention(
 
   def topicEvents(name: String): String = topic(name, KafkaNamingConvention.EVENTS)
   def topicCommands(name: String): String = topic(name, KafkaNamingConvention.COMMANDS)
-  def topicSnapshots(name: String): String = topic(name, KafkaNamingConvention.SNAPSHOTS)
 
   /**
-   * Changelog topic name is fixed and follows always the convention `{appId}-{storeName}-changelog``
+   * Changelog topic name is fixed and follows always the convention `{appId}-{storeName}-changelog`
    */
   def topicStoreChangelog(storeName: String): String = topic(storeName, KafkaNamingConvention.CHANGELOG)
 

--- a/es4kafka/src/main/scala/es4kafka/kafka/KafkaNamingConvention.scala
+++ b/es4kafka/src/main/scala/es4kafka/kafka/KafkaNamingConvention.scala
@@ -2,21 +2,29 @@ package es4kafka.kafka
 
 class KafkaNamingConvention(
     applicationId: String,
-    boundedContext: String
 ) {
-  def kafkaEventsTopic(name: String): String = s"$boundedContext.$name.events"
-  def kafkaCommandsTopic(name: String): String = s"$boundedContext.$name.commands"
-  def kafkaSnapshotsTopic(name: String): String = s"$boundedContext.$name.snapshots"
+  /**
+   * Use the same convention of the changelog to have the same names on topics
+   */
+  def topic(name: String, kind: String): String = s"$applicationId-$name-$kind"
 
-  def kafkaStreamsChangelogTopic(storeName: String): String = s"$applicationId-$storeName-changelog"
-  def kafkaStreamsStore(name: String): String = name
+  def topicEvents(name: String): String = topic(name, "events")
+  def topicCommands(name: String): String = topic(name, "commands")
+  def topicSnapshots(name: String): String = topic(name, "snapshots")
+
+  /**
+   * Changelog topic name is fixed and follows always the convention `{appId}-{storeName}-changelog``
+   */
+  def topicStoreChangelog(storeName: String): String = topic(storeName, "changelog")
+
+  def store(name: String): String = name
 
   /**
    * Returns a group id used for Kafka. It will be composed by "{applicationId}-{scenario}"
    * Group Id must unique for each use case, for example when creating a new Akka Stream consumer you should provide an
    * unique group id. For Kafka Stream groupId is only composed by applicationId.
-   * @param scenarioGroupId Unique name of the use case inside an application.
+   * @param scenario Unique name of the use case inside an application.
    * @return The group id
    */
-  def groupId(scenarioGroupId: String) = s"$applicationId-$scenarioGroupId"
+  def groupId(scenario: String) = s"$applicationId-$scenario"
 }

--- a/es4kafka/src/main/scala/es4kafka/streaming/DefaultProjectionStateReader.scala
+++ b/es4kafka/src/main/scala/es4kafka/streaming/DefaultProjectionStateReader.scala
@@ -20,7 +20,7 @@ class DefaultProjectionStateReader[TKey: Serde, TValue: RootJsonFormat] (
 
   def fetchAll(onlyLocal: Boolean): Future[Seq[TValue]] = {
     fetchAll(
-      projectionConfig.storeSnapshots,
+      projectionConfig.storeChangelog,
       fetchAllRemotePath,
       onlyLocal
     )
@@ -28,7 +28,7 @@ class DefaultProjectionStateReader[TKey: Serde, TValue: RootJsonFormat] (
 
   def fetchOne(key: TKey): Future[Option[TValue]] = {
     fetchOne(
-      _ => projectionConfig.storeSnapshots,
+      _ => projectionConfig.storeChangelog,
       fetchOneRemotePath,
       key
     )

--- a/es4kafka/src/main/scala/es4kafka/streaming/DefaultSnapshotsStateReader.scala
+++ b/es4kafka/src/main/scala/es4kafka/streaming/DefaultSnapshotsStateReader.scala
@@ -20,7 +20,7 @@ class DefaultSnapshotsStateReader[TKey: Serde, TValue <: StatefulEntity : RootJs
 
   def fetchAll(onlyLocal: Boolean): Future[Seq[TValue]] = {
     fetchAll(
-      aggregateConfig.storeSnapshots,
+      aggregateConfig.storeChangelog,
       fetchAllRemotePath,
       onlyLocal
     ).map(items => items.filter(_.isValid))
@@ -28,7 +28,7 @@ class DefaultSnapshotsStateReader[TKey: Serde, TValue <: StatefulEntity : RootJs
 
   def fetchOne(key: TKey): Future[Option[TValue]] = {
     fetchOne(
-      _ => aggregateConfig.storeSnapshots,
+      _ => aggregateConfig.storeChangelog,
       fetchOneRemotePath,
       key
     ).map(item => item.filter(_.isValid))

--- a/es4kafka/src/main/scala/es4kafka/streaming/es/EventSourcingTopology.scala
+++ b/es4kafka/src/main/scala/es4kafka/streaming/es/EventSourcingTopology.scala
@@ -20,7 +20,7 @@ abstract class EventSourcingTopology[TKey, TCommand, TEvent, TState >: Null](
   var eventsStream: KStream[TKey, Envelop[TEvent]] = _
 
   def snapshotsTable(streamsBuilder: StreamsBuilder): KTable[TKey, TState] = {
-    streamsBuilder.table[TKey, TState](aggregateConfig.topicSnapshots)
+    streamsBuilder.table[TKey, TState](aggregateConfig.topicChangelog)
   }
 
   def prepare(streamsBuilder: StreamsBuilder): Unit = {
@@ -32,7 +32,7 @@ abstract class EventSourcingTopology[TKey, TCommand, TEvent, TState >: Null](
     //  failed to initialize processor
     //  Processor .. has no access to StateStore
     eventsStream = commandsStream.transformValues(
-      new EventSourcingTransformerSupplier(aggregateConfig.storeSnapshots, aggregateConfig.storeEventsByMsgId, this)
+      new EventSourcingTransformerSupplier(aggregateConfig.storeChangelog, aggregateConfig.storeEventsByMsgId, this)
     ).flatMapValues(v => v)
     eventsStream.to(aggregateConfig.topicEvents)
   }

--- a/es4kafka/src/main/scala/es4kafka/streaming/es/EventSourcingTopology.scala
+++ b/es4kafka/src/main/scala/es4kafka/streaming/es/EventSourcingTopology.scala
@@ -19,7 +19,7 @@ abstract class EventSourcingTopology[TKey, TCommand, TEvent, TState >: Null](
   var commandsStream: KStream[TKey, Envelop[TCommand]] = _
   var eventsStream: KStream[TKey, Envelop[TEvent]] = _
 
-  def snapshotsTable(streamsBuilder: StreamsBuilder): KTable[TKey, TState] = {
+  def changelogTable(streamsBuilder: StreamsBuilder): KTable[TKey, TState] = {
     streamsBuilder.table[TKey, TState](aggregateConfig.topicChangelog)
   }
 

--- a/es4kafka/src/main/scala/es4kafka/streaming/es/EventSourcingTopology.scala
+++ b/es4kafka/src/main/scala/es4kafka/streaming/es/EventSourcingTopology.scala
@@ -5,7 +5,6 @@ import org.apache.kafka.common.serialization.Serde
 import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala.StreamsBuilder
 import org.apache.kafka.streams.scala.kstream._
-import org.apache.kafka.streams.state.Stores
 
 abstract class EventSourcingTopology[TKey, TCommand, TEvent, TState >: Null](
     aggregateConfig: AggregateConfig,
@@ -19,7 +18,10 @@ abstract class EventSourcingTopology[TKey, TCommand, TEvent, TState >: Null](
 
   var commandsStream: KStream[TKey, Envelop[TCommand]] = _
   var eventsStream: KStream[TKey, Envelop[TEvent]] = _
-  var snapshotsTable: KTable[TKey, TState] = _
+
+  def snapshotsTable(streamsBuilder: StreamsBuilder): KTable[TKey, TState] = {
+    streamsBuilder.table[TKey, TState](aggregateConfig.topicSnapshots)
+  }
 
   def prepare(streamsBuilder: StreamsBuilder): Unit = {
     // Commands
@@ -30,18 +32,9 @@ abstract class EventSourcingTopology[TKey, TCommand, TEvent, TState >: Null](
     //  failed to initialize processor
     //  Processor .. has no access to StateStore
     eventsStream = commandsStream.transformValues(
-      new EventSourcingTransformerSupplier(aggregateConfig.storeState, aggregateConfig.storeEventsByMsgId, this)
+      new EventSourcingTransformerSupplier(aggregateConfig.storeSnapshots, aggregateConfig.storeEventsByMsgId, this)
     ).flatMapValues(v => v)
     eventsStream.to(aggregateConfig.topicEvents)
-
-    // Snapshots (copy from changelog)
-    // I essentially copy that to do not rely on the "changelog" topic that is handled by Kafka Streams.
-    streamsBuilder
-      .stream[TKey, TState](aggregateConfig.topicStateChangelog)
-      .to(aggregateConfig.topicSnapshots)
-    val snapshotsStore = Stores.inMemoryKeyValueStore(aggregateConfig.storeSnapshots)
-    val materializedSnapshots = Materialized.as[TKey, TState](snapshotsStore)
-    snapshotsTable = streamsBuilder.table[TKey, TState](aggregateConfig.topicSnapshots, materializedSnapshots)
   }
 }
 

--- a/es4kafka/src/test/scala/es4kafka/akkaStream/PassThroughFlowSpec.scala
+++ b/es4kafka/src/test/scala/es4kafka/akkaStream/PassThroughFlowSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funspec.AsyncFunSpecLike
 import org.scalatest.matchers.should.Matchers
 
-class PassThroughFlowSpec extends TestKit(ActorSystem("AdapterControlGraphSpec")) with AsyncFunSpecLike with BeforeAndAfterAll with Matchers {
+class PassThroughFlowSpec extends TestKit(ActorSystem("PassThroughFlowSpec")) with AsyncFunSpecLike with BeforeAndAfterAll with Matchers {
   override protected def afterAll(): Unit = TestKit.shutdownActorSystem(system)
 
   describe("PassThroughFlow") {

--- a/examples/bank-account/src/it/scala/bank/BankIntegrationTest.scala
+++ b/examples/bank-account/src/it/scala/bank/BankIntegrationTest.scala
@@ -1,15 +1,11 @@
 package bank
 
 import com.davideicardi.kaa.SchemaRegistry
-import com.typesafe.config.ConfigFactory
 import es4kafka.serialization.CommonAvroSerdes._
 import es4kafka.testing.ServiceAppIntegrationSpec
 import net.codingwell.scalaguice.InjectorExtensions._
 
 class BankIntegrationTest extends ServiceAppIntegrationSpec("BankIntegrationTest") {
-  it("should read correct config") {
-    ConfigFactory.load().getString("es4kafka.service.applicationId") should be ("bank-it")
-  }
   it("should override config") {
     Config.applicationId should be("bank-it")
     Config.boundedContext should be("sample")

--- a/examples/books-catalog/src/it/scala/catalog/CatalogIntegrationTest.scala
+++ b/examples/books-catalog/src/it/scala/catalog/CatalogIntegrationTest.scala
@@ -34,14 +34,14 @@ class CatalogIntegrationTest extends ServiceAppIntegrationSpec("CatalogIntegrati
         )
         authorCreatedEvent <- http.fetch[EventList[AuthorEvent]](Uri(s"http://localhost:9081/authors/events/one/${createAuthorResponse.uuid}"))
         kafkaEvents <- readAllKafkaRecords[String, Envelop[AuthorEvent]](injector, Config.Author.topicEvents, 1)
-        kafkaSnapshots <- readAllKafkaRecords[String, Author](injector, Config.Author.topicSnapshots, 1)
+        kafkaSnapshots <- readAllKafkaRecords[String, Author](injector, Config.Author.topicChangelog, 1)
       } yield {
         authorCreatedEvent should be(EventList.single(AuthorCreated("king", "Stephen", "King")))
-        kafkaEvents should have size (1)
+        kafkaEvents should have size 1
         kafkaEvents should be(Seq(
           "king" -> Envelop(createAuthorResponse, AuthorCreated("king", "Stephen", "King"))
         ))
-        kafkaSnapshots should have size (1)
+        kafkaSnapshots should have size 1
         kafkaSnapshots should be(Seq(
           "king" -> Author(EntityStates.VALID, "king", "Stephen", "King")
         ))
@@ -95,14 +95,14 @@ class CatalogIntegrationTest extends ServiceAppIntegrationSpec("CatalogIntegrati
           Uri("http://localhost:9081/books/commands"),
           SetBookAuthor(bookId, Some("king"))
         )
-        kafkaBCSnapshots <- readAllKafkaRecords[UUID, BookCard](injector, Config.BookCard.topicSnapshots, 1)
+        kafkaBCSnapshots <- readAllKafkaRecords[UUID, BookCard](injector, Config.BookCard.topicChangelog, 1)
         cards <- http.fetch[Seq[BookCard]](Uri("http://localhost:9081/booksCards/all"))
       } yield {
         val expectedBookCard = BookCard(Book(bookId, "Misery", Some("king")), Author("king", "Stephen", "King"))
         kafkaBCSnapshots should be(Seq(
           bookId -> expectedBookCard
         ))
-        cards should have size (1)
+        cards should have size 1
         cards should be(Seq(
           expectedBookCard
         ))

--- a/examples/books-catalog/src/main/scala/catalog/books/akkaStream/BookPrinterGraph.scala
+++ b/examples/books-catalog/src/main/scala/catalog/books/akkaStream/BookPrinterGraph.scala
@@ -32,7 +32,7 @@ class BookPrinterGraph @Inject()(
     consumerFactory
       .readTopicGraph[UUID, Book](
         scenarioGroupId,
-        Subscriptions.topics(Config.Book.topicSnapshots),
+        Subscriptions.topics(Config.Book.topicChangelog),
         PassThroughFlow(
           Flow[CommittableMessage[UUID, Book]]
             .map(_.record.value())

--- a/examples/books-catalog/src/main/scala/catalog/booksCards/streaming/BooksCardsTopology.scala
+++ b/examples/books-catalog/src/main/scala/catalog/booksCards/streaming/BooksCardsTopology.scala
@@ -21,7 +21,7 @@ class BooksCardsTopology()(
       authorTable: KTable[String, Author],
   ): Unit = {
     val storeSnapshots =
-      Stores.inMemoryKeyValueStore(Config.BookCard.storeSnapshots)
+      Stores.inMemoryKeyValueStore(Config.BookCard.storeChangelog)
 
     val _ = bookTable
       .filter((_, v) => v.author.isDefined)

--- a/examples/books-catalog/src/main/scala/catalog/booksCards/streaming/BooksCardsTopology.scala
+++ b/examples/books-catalog/src/main/scala/catalog/booksCards/streaming/BooksCardsTopology.scala
@@ -9,28 +9,27 @@ import catalog.booksCards._
 import es4kafka.serialization.CommonAvroSerdes._
 import com.davideicardi.kaa.SchemaRegistry
 import org.apache.kafka.streams.scala.kstream._
-import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.state.Stores
 import es4kafka.EntityStates
 
-class BooksCardsTopology(
-    bookTable: KTable[UUID, Book],
-    authorTable: KTable[String, Author],
-)(
+class BooksCardsTopology()(
     implicit schemaRegistry: SchemaRegistry
 ) {
 
-  private val storeSnapshots =
-    Stores.inMemoryKeyValueStore(Config.BookCard.storeSnapshots)
-  
-  val bookWithAuthorTable: KTable[UUID, BookCard] = bookTable
-    .filter((_, v) => v.author.isDefined)
-    .join(
-      authorTable.filter((_, v) => v.state == EntityStates.VALID),  // table to join
-      (book: Book) => book.author.getOrElse(""),                    // Foreign Key
-      (book: Book, author: Author) => BookCard(book, author),       // joiner
-      Materialized.as(storeSnapshots)
-    )
+  def prepare(
+      bookTable: KTable[UUID, Book],
+      authorTable: KTable[String, Author],
+  ): Unit = {
+    val storeSnapshots =
+      Stores.inMemoryKeyValueStore(Config.BookCard.storeSnapshots)
 
-  bookWithAuthorTable.toStream.to(Config.BookCard.topicSnapshots)
+    val _ = bookTable
+      .filter((_, v) => v.author.isDefined)
+      .join(
+        authorTable.filter((_, v) => v.state == EntityStates.VALID),  // table to join
+        (book: Book) => book.author.getOrElse(""),                    // Foreign Key
+        (book: Book, author: Author) => BookCard(book, author),       // joiner
+        Materialized.as[UUID, BookCard](storeSnapshots)
+      )
+  }
 }

--- a/examples/books-catalog/src/main/scala/catalog/streaming/StreamingPipeline.scala
+++ b/examples/books-catalog/src/main/scala/catalog/streaming/StreamingPipeline.scala
@@ -29,7 +29,8 @@ class StreamingPipeline @Inject()(
     books.prepare(streamBuilder)
 
     logger.info("Create bookcards topology ...")
-    new BooksCardsTopology(books.snapshotsTable(streamBuilder), authors.snapshotsTable(streamBuilder))
+    val booksCards = new BooksCardsTopology()
+    booksCards.prepare(books.snapshotsTable(streamBuilder), authors.snapshotsTable(streamBuilder))
 
     streamBuilder
   }

--- a/examples/books-catalog/src/main/scala/catalog/streaming/StreamingPipeline.scala
+++ b/examples/books-catalog/src/main/scala/catalog/streaming/StreamingPipeline.scala
@@ -30,7 +30,7 @@ class StreamingPipeline @Inject()(
 
     logger.info("Create bookcards topology ...")
     val booksCards = new BooksCardsTopology()
-    booksCards.prepare(books.snapshotsTable(streamBuilder), authors.snapshotsTable(streamBuilder))
+    booksCards.prepare(books.changelogTable(streamBuilder), authors.changelogTable(streamBuilder))
 
     streamBuilder
   }

--- a/examples/books-catalog/src/main/scala/catalog/streaming/StreamingPipeline.scala
+++ b/examples/books-catalog/src/main/scala/catalog/streaming/StreamingPipeline.scala
@@ -29,7 +29,7 @@ class StreamingPipeline @Inject()(
     books.prepare(streamBuilder)
 
     logger.info("Create bookcards topology ...")
-    new BooksCardsTopology(books.snapshotsTable, authors.snapshotsTable)
+    new BooksCardsTopology(books.snapshotsTable(streamBuilder), authors.snapshotsTable(streamBuilder))
 
     streamBuilder
   }

--- a/examples/books-catalog/src/test/scala/catalog/streaming/StreamingPipelineSpec.scala
+++ b/examples/books-catalog/src/test/scala/catalog/streaming/StreamingPipelineSpec.scala
@@ -157,7 +157,7 @@ class StreamingPipelineSpec extends AnyFunSpec with Matchers with MockFactory {
         booksTest.pipeCommand(SetBookAuthor(bookId3, Some("eco")))
         authorsTest.pipeCommand(DeleteAuthor("eco"))
 
-        val snapshotTopic = new OutputTopicTest[UUID, BookCard](driver, Config.BookCard.topicSnapshots)
+        val snapshotTopic = new OutputTopicTest[UUID, BookCard](driver, Config.BookCard.topicChangelog)
         val snapshots = snapshotTopic.readValuesToSeq()
         snapshots should have size 4
         snapshots should contain(


### PR DESCRIPTION
Use changelog topic and corresponding state store instead, to avoid duplication of memory and storage.

Proposal is to change the topic convetion to have `{appId}-{name}-{type}`. Type can be `events`, `commands` or `changelog`. Name is the aggregate name. App id is the name of the service (without the bounded context).

Examples:

- `catalog-books-commands`
- `catalog-books-events`
- `catalog-books-changelog`

In this way we adopt the same convention as Kafka Streams.

Having the application id inside the topic name is probably a good thing to maintain backward compatibility. Because in this way if we break compatibility all we have to do is to change application id. So for example we can have `catalog` that will became `catalogV2`... And topic names will follow the app and we will not have incosistence.

PRO:
- no duplicated topic and state store (less memory usage and storage)
- same naming convention of kakfa streams

CONS:
- we should change the topic name convention and also change the readers of these topics
- we don't have full control on snapshots topic, but if this will change it will be a major change, it is something in the public interface and well documented
